### PR TITLE
fix: 修复接口参数校验问题以及镜像启动失败问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 EXPOSE 8000
 
 # 运行应用
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "app/main.py"]

--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,11 @@ async def decode_image(image: Union[UploadFile, StarletteUploadFile, str, None])
         raise HTTPException(status_code=400, detail="No image provided")
 
     if isinstance(image, (UploadFile, StarletteUploadFile)):
-        return await image.read()
+        content = await image.read()
+        if not content:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+        return content
+    
     elif isinstance(image, str):
         try:
             # 检查是否是 base64 编码的图片
@@ -38,7 +42,7 @@ async def ocr_endpoint(
         png_fix: bool = Form(False)
 ):
     try:
-        if file.size == 0 and image is None:
+        if file is None and image is None:
             return APIResponse(code=400, message="Either file or image must be provided")
 
         image_bytes = await decode_image(file or image)
@@ -57,7 +61,7 @@ async def slide_match_endpoint(
         simple_target: bool = Form(False)
 ):
     try:
-        if (background is None and target is None) or (background_file.size == 0 and target_file.size == 0):
+        if (target_file is None and target is None) or (background_file is None and background is None):
             return APIResponse(code=400, message="Both target and background must be provided")
 
         target_bytes = await decode_image(target_file or target)
@@ -74,7 +78,7 @@ async def detection_endpoint(
         image: Optional[str] = Form(None)
 ):
     try:
-        if file.size == 0 and image is None:
+        if file is None and image is None:
             return APIResponse(code=400, message="Either file or image must be provided")
 
         image_bytes = await decode_image(file or image)


### PR DESCRIPTION
关于你之前说的“file.size那块可能得再考虑一下，我记得测试的时候直接判断为None会有问题”
我在 `decode_image` 里加了空文件判断，能解决你的这个考虑